### PR TITLE
Option to use a non-system resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ dnscan.py (-d \<domain\> | -l \<list\>) [OPTIONS]
     -6 --ipv6                                 Scan for IPv6 records (AAAA)
     -z --zonetransfer                         Perform zone transfer and exit
     -r --recursive                            Recursively scan subdomains
+    -R --resolver <resolver>                  Use the specified resolver instead of the system default
     -T --tld                                  Scan for the domain in all TLDs
     -o --output <filename>                    Output to a text file
     -i --output-ips <filename>                Output discovered IP addresses to a text file

--- a/dnscan.py
+++ b/dnscan.py
@@ -249,6 +249,7 @@ def get_args():
     parser.add_argument('-6', '--ipv6', help='Scan for AAAA records', action="store_true", dest='ipv6', required=False, default=False)
     parser.add_argument('-z', '--zonetransfer', action="store_true", default=False, help='Only perform zone transfers', dest='zonetransfer', required=False)
     parser.add_argument('-r', '--recursive', action="store_true", default=False, help="Recursively scan subdomains", dest='recurse', required=False)
+    parser.add_argument('-R', '--resolver', help="Use the specified resolver instead of the system default", dest='resolver', required=False)
     parser.add_argument('-T', '--tld', action="store_true", default=False, help="Scan for TLDs", dest='tld', required=False)
     parser.add_argument('-o', '--output', help="Write output to a file", dest='output_filename', required=False)
     parser.add_argument('-i', '--output-ips',   help="Write discovered IP addresses to a file", dest='output_ips', required=False)
@@ -292,6 +293,8 @@ def setup():
     queue = Queue.Queue()
     resolver = dns.resolver.Resolver()
     resolver.timeout = 1
+    if args.resolver:
+        resolver.nameservers = [ args.resolver ]
 
     # Record type
     if args.ipv6:


### PR DESCRIPTION
So I recently found myself needing to run dnscan from a resolver other than the one I had specified in `resolv.conf`. We use split horizon DNS, and I wanted to see what was visible externally.

As dnspython has the [option of using custom resolvers](http://www.dnspython.org/docs/1.15.0/dns.resolver.Resolver-class.html#nameservers) I've added it as an extra flag you can specify.

Hope this is useful enough to be merged!